### PR TITLE
ハッシュフラグメント追加、小字名の表示追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,6 +577,7 @@
                 var koazakodo = e.features[0].properties['小字コード'];
                 var yobikodo = e.features[0].properties['予備コード'];
                 var oazamei = e.features[0].properties['大字名'];
+                var koazamei = e.features[0].properties['小字名'];
                 var chiban = e.features[0].properties['地番'];
                 var seidokubun = e.features[0].properties['精度区分'];
                 var zahyochishubetsu = e.features[0].properties['座標値種別'];
@@ -593,6 +594,7 @@
                 if (koazakodo === undefined) { koazakodo = "-" };
                 if (yobikodo === undefined) { yobikodo = "-" };
                 if (oazamei === undefined) { oazamei = "-" };
+                if (koazamei === undefined) { koazamei = "-" };
                 if (chiban === undefined) { chiban = "-" };
                 if (seidokubun === undefined) { seidokubun = "-" };
                 if (zahyochishubetsu === undefined) { zahyochishubetsu = "-" };
@@ -611,6 +613,7 @@
                         + '小字コード: ' + koazakodo + '<br>'
                         + '予備コード: ' + yobikodo + '<br>'
                         + '大字名: ' + oazamei + '<br>'
+                        + '小字名: ' + koazamei + '<br>'
                         + '地番: ' + chiban + '<br>'
                         + '精度区分: ' + seidokubun + '<br>'
                         + '座標値種別: ' + zahyochishubetsu + '<br>'

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
             container: 'map',
             style: './std.json',
             // style: 'https://gsi-cyberjapan.github.io/gsivectortile-mapbox-gl-js/std.json',
+            hash: true,
             zoom: 14,
             maxZoom: 23,
             minZoom: 4,


### PR DESCRIPTION
以下の２点につきまして、コードを修正しております。
・URLにズームレベル及び経緯度のハッシュフラグメントを表示
　（URLで表示位置などを共有できるように）
・吹き出しに小字名を表示
　（小字単位で地番が割り振られている地域など、もとのデータに小字名がある場合に表示）
どうぞよろしくお願いします。